### PR TITLE
moved all curapacs k8s objects to 2 namespaces (curapacs / curapacs-l…

### DIFF
--- a/kubernetes/globals/globals.yml
+++ b/kubernetes/globals/globals.yml
@@ -8,5 +8,5 @@ metadata:
     app.kubernetes.io/part-of: ingress-nginx
   namespace: ingress-nginx
 data:
-  4243: "pacsaas-c0100/orthanc-dicom:4242"
-  4243: "pacsaas-c0100-local/orthanc-dicom:4243"
+  4243: "curapacs/orthanc-dicom:4242"
+  4243: "curapacs-local/orthanc-dicom-local:4243"

--- a/kubernetes/meddream-tokenservice/manifest.yml
+++ b/kubernetes/meddream-tokenservice/manifest.yml
@@ -3,10 +3,16 @@ apiVersion: v1
 kind: Service
 metadata:
   name: tokenservice
-  namespace: pacsaas-c0100
+  namespace: curapacs
+  labels:
+    app.kubernetes.io/name: meddream-tokenservice
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 spec:
   selector:
-    app: meddream-tokenservice
+    app.kubernetes.io/name: meddream-tokenservice
+    curamed.ch/customer: c0100
   ports:
     - name: tokenservice
       protocol: TCP
@@ -16,7 +22,12 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: meddream-tokenservice-application-properties-cm 
-  namespace: pacsaas-c0100
+  namespace: curapacs
+  labels:
+    app.kubernetes.io/name: meddream-tokenservice
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 data:
   application.properties: |-
     server.port=80
@@ -34,7 +45,12 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: c0100-meddream-tokenservice
-  namespace: pacsaas-c0100
+  namespace: curapacs
+  labels:
+    app.kubernetes.io/name: meddream-tokenservice
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 spec:
   rules:
   - host: c0100-meddream-tokenservice.curapacs.ch
@@ -49,18 +65,27 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: meddream-tokenservice-deployment
+  namespace: curapacs
   labels:
-    app: meddream-tokenservice
-  namespace: pacsaas-c0100
+    app.kubernetes.io/name: meddream-tokenservice
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: meddream-tokenservice
+      app.kubernetes.io/name: meddream-tokenservice
+      app.kubernetes.io/version: "1.0"
+      app.kubernetes.io/managed-by: curapacs-provisioner
+      curamed.ch/customer: c0100
   template:
     metadata:
       labels:
-        app: meddream-tokenservice
+        app.kubernetes.io/name: meddream-tokenservice
+        app.kubernetes.io/version: "1.0"
+        app.kubernetes.io/managed-by: curapacs-provisioner
+        curamed.ch/customer: c0100
     spec:
       automountServiceAccountToken: false
       securityContext:

--- a/kubernetes/meddream-viewer/manifest.yml
+++ b/kubernetes/meddream-viewer/manifest.yml
@@ -3,10 +3,16 @@ apiVersion: v1
 kind: Service
 metadata:
   name: meddream-viewer
-  namespace: pacsaas-c0100
+  namespace: curapacs
+  labels:
+    app.kubernetes.io/name: meddream-viewer
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 spec:
   selector:
-    app: meddream-viewer
+    app.kubernetes.io/name: meddream-viewer
+    curamed.ch/customer: c0100
   ports:
     - name: meddream-viewer
       protocol: TCP
@@ -16,7 +22,12 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: meddream-application-properties-cm 
-  namespace: pacsaas-c0100
+  namespace: curapacs
+  labels:
+    app.kubernetes.io/name: meddream-viewer
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 data:
   application.properties: |-
     com.softneta.license.licenseFileLocation=./license
@@ -46,7 +57,12 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: c0100-meddream
-  namespace: pacsaas-c0100
+  namespace: curapacs
+  labels:
+    app.kubernetes.io/name: meddream-viewer
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 spec:
   rules:
   - host: c0100-meddream.curapacs.ch
@@ -61,18 +77,27 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: meddream-viewer-deployment
+  namespace: curapacs
   labels:
-    app: meddream-viewer
-  namespace: pacsaas-c0100
+    app.kubernetes.io/name: meddream-viewer
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: meddream-viewer
+      app.kubernetes.io/name: meddream-viewer
+      app.kubernetes.io/version: "1.0"
+      app.kubernetes.io/managed-by: curapacs-provisioner
+      curamed.ch/customer: c0100
   template:
     metadata:
       labels:
-        app: meddream-viewer
+        app.kubernetes.io/name: meddream-viewer
+        app.kubernetes.io/version: "1.0"
+        app.kubernetes.io/managed-by: curapacs-provisioner
+        curamed.ch/customer: c0100
     spec:
       automountServiceAccountToken: false
       securityContext:

--- a/kubernetes/orthanc-peer/manifest.yml
+++ b/kubernetes/orthanc-peer/manifest.yml
@@ -4,10 +4,16 @@ apiVersion: v1
 kind: Service
 metadata:
   name: orthanc-postgres
-  namespace: pacsaas-c0100-local
+  namespace: curapacs-local
+  labels:
+    app.kubernetes.io/name: orthanc-postgres
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 spec:
   selector:
-    app: orthanc-postgres
+    app.kubernetes.io/name: orthanc-postgres
+    curamed.ch/customer: c0100
   ports:
     - name: orthanc-postgres
       protocol: TCP
@@ -17,18 +23,27 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: orthanc-postgres-deployment
-  namespace: pacsaas-c0100-local
+  namespace: curapacs-local
   labels:
-    app: orthanc-postgres
+    app.kubernetes.io/name: orthanc-postgres
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: orthanc-postgres
+      app.kubernetes.io/name: orthanc-postgres
+      app.kubernetes.io/version: "1.0"
+      app.kubernetes.io/managed-by: curapacs-provisioner
+      curamed.ch/customer: c0100
   template:
     metadata:
       labels:
-        app: orthanc-postgres
+        app.kubernetes.io/name: orthanc-postgres
+        app.kubernetes.io/version: "1.0"
+        app.kubernetes.io/managed-by: curapacs-provisioner
+        curamed.ch/customer: c0100
     spec:
       automountServiceAccountToken: false
       containers:
@@ -53,10 +68,16 @@ apiVersion: v1
 kind: Service
 metadata:
   name: orthanc-web
-  namespace: pacsaas-c0100-local
+  namespace: curapacs-local
+  labels:
+    app.kubernetes.io/name: orthanc
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 spec:
   selector:
-    app: orthanc
+    app.kubernetes.io/name: orthanc
+    curamed.ch/customer: c0100
   ports:
     - name: orthanc-web
       protocol: TCP
@@ -66,10 +87,16 @@ apiVersion: v1
 kind: Service
 metadata:
   name: orthanc-dicom
-  namespace: pacsaas-c0100-local
+  namespace: curapacs-local
+  labels:
+    app.kubernetes.io/name: orthanc
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 spec:
   selector:
-    app: orthanc
+    app.kubernetes.io/name: orthanc
+    curamed.ch/customer: c0100
   ports:
     - name: orthanc-dicom
       protocol: TCP
@@ -79,7 +106,12 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: c0100-orthanc
-  namespace: pacsaas-c0100-local
+  namespace: curapacs-local
+  labels:
+    app.kubernetes.io/name: orthanc
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 spec:
   rules:
   - host: c0100-peer.curapacs.ch
@@ -94,7 +126,12 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: orthanc-postgresql-config-cm
-  namespace: pacsaas-c0100-local
+  namespace: curapacs-local
+  labels:
+    app.kubernetes.io/name: orthanc
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 data:
   postgresql.json: |-
     {
@@ -114,7 +151,12 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: orthanc-dicom-config-cm
-  namespace: pacsaas-c0100-local
+  namespace: curapacs-local
+  labels:
+    app.kubernetes.io/name: orthanc
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 data:
   dicom.json: |-
     {
@@ -138,7 +180,12 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: orthanc-peering-config-cm
-  namespace: pacsaas-c0100-local
+  namespace: curapacs-local
+  labels:
+    app.kubernetes.io/name: orthanc
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 data:
   peering.json: |-
     { "OrthancPeers": {"orthanc" : [ "http://c0100-orthanc.curapacs.ch" ] } }
@@ -147,7 +194,12 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: orthanc-remote-access-config-cm
-  namespace: pacsaas-c0100-local
+  namespace: curapacs-local
+  labels:
+    app.kubernetes.io/name: orthanc
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 data:
   remote-access.json: |-
     {
@@ -160,7 +212,12 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: orthanc-python-config-cm
-  namespace: pacsaas-c0100-local
+  namespace: curapacs-local
+  labels:
+    app.kubernetes.io/name: orthanc
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 data:
   python.json: |-
     {
@@ -172,7 +229,12 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: orthanc-http-config-cm
-  namespace: pacsaas-c0100-local
+  namespace: curapacs-local
+  labels:
+    app.kubernetes.io/name: orthanc
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 data:
   http.json: |-
     {
@@ -191,18 +253,27 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: orthanc-deployment
+  namespace: curapacs-local
   labels:
-    app: orthanc
-  namespace: pacsaas-c0100-local
+    app.kubernetes.io/name: orthanc
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: orthanc
+      app.kubernetes.io/name: orthanc
+      app.kubernetes.io/version: "1.0"
+      app.kubernetes.io/managed-by: curapacs-provisioner
+      curamed.ch/customer: c0100
   template:
     metadata:
       labels:
-        app: orthanc
+        app.kubernetes.io/name: orthanc
+        app.kubernetes.io/version: "1.0"
+        app.kubernetes.io/managed-by: curapacs-provisioner
+        curamed.ch/customer: c0100
     spec:
       automountServiceAccountToken: false
       securityContext:

--- a/kubernetes/orthanc-postgres/manifest.yml
+++ b/kubernetes/orthanc-postgres/manifest.yml
@@ -3,10 +3,16 @@ apiVersion: v1
 kind: Service
 metadata:
   name: orthanc-postgres
-  namespace: pacsaas-c0100
+  namespace: curapacs
+  labels:
+    app.kubernetes.io/name: orthanc-postgres
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 spec:
   selector:
-    app: orthanc-postgres
+    app.kubernetes.io/name: orthanc-postgres
+    curamed.ch/customer: c0100
   ports:
     - name: orthanc-postgres
       protocol: TCP
@@ -16,18 +22,27 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: orthanc-postgres-deployment
+  namespace: curapacs
   labels:
-    app: orthanc-postgres
-  namespace: pacsaas-c0100
+    app.kubernetes.io/name: orthanc-postgres
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: orthanc-postgres
+      app.kubernetes.io/name: orthanc-postgres
+      app.kubernetes.io/version: "1.0"
+      app.kubernetes.io/managed-by: curapacs-provisioner
+      curamed.ch/customer: c0100
   template:
     metadata:
       labels:
-        app: orthanc-postgres
+        app.kubernetes.io/name: orthanc-postgres
+        app.kubernetes.io/version: "1.0"
+        app.kubernetes.io/managed-by: curapacs-provisioner
+        curamed.ch/customer: c0100
     spec:
       automountServiceAccountToken: false
       containers:

--- a/kubernetes/orthanc/manifest.yml
+++ b/kubernetes/orthanc/manifest.yml
@@ -4,33 +4,50 @@ apiVersion: v1
 kind: Service
 metadata:
   name: orthanc-web
-  namespace: pacsaas-c0100
+  namespace: curapacs
+  labels:
+    app.kubernetes.io/name: orthanc
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 spec:
   selector:
-    app: orthanc
+    app.kubernetes.io/name: orthanc
+    curamed.ch/customer: c0100
   ports:
-    - name: orthanc-web
-      protocol: TCP
-      port: 8080
+  - name: orthanc-web
+    protocol: TCP
+    port: 8080
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: orthanc-dicom
-  namespace: pacsaas-c0100
+  namespace: curapacs
+  labels:
+    app.kubernetes.io/name: orthanc
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 spec:
   selector:
-    app: orthanc
+    app.kubernetes.io/name: orthanc
+    curamed.ch/customer: c0100
   ports:
-    - name: orthanc-dicom
-      protocol: TCP
-      port: 4242
+  - name: orthanc-dicom
+    protocol: TCP
+    port: 4242
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: c0100-orthanc
-  namespace: pacsaas-c0100
+  namespace: curapacs
+  labels:
+    app.kubernetes.io/name: orthanc
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 spec:
   rules:
   - host: c0100-orthanc.curapacs.ch
@@ -45,7 +62,12 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: orthanc-config-cm
-  namespace: pacsaas-c0100
+  namespace: curapacs
+  labels:
+    app.kubernetes.io/name: orthanc
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 data:
   DICOM_MODALITIES: '{ "Befundungsstation" : [ "BAG_MONITOR", "192.168.0.8", 11112 ], "FINDSCU-UTILITY": [ "FINDSCU", "10.42.0.1", 104 ] }'
   AC_REGISTERED_USERS: '{ "orthanc": "orthanc" }'
@@ -56,24 +78,32 @@ data:
   PG_DB: "orthanc"
   PG_USER: "orthanc"
   PG_PASSWORD: "orthanc"
-  
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: orthanc-deployment
+  namespace: curapacs
   labels:
-    app: orthanc
-  namespace: pacsaas-c0100
+    app.kubernetes.io/name: orthanc
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: curapacs-provisioner
+    curamed.ch/customer: c0100
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: orthanc
+      app.kubernetes.io/name: orthanc
+      app.kubernetes.io/version: "1.0"
+      app.kubernetes.io/managed-by: curapacs-provisioner
+      curamed.ch/customer: c0100
   template:
     metadata:
       labels:
-        app: orthanc
+        app.kubernetes.io/name: orthanc
+        app.kubernetes.io/version: "1.0"
+        app.kubernetes.io/managed-by: curapacs-provisioner
+        curamed.ch/customer: c0100
     spec:
       automountServiceAccountToken: false
       containers:


### PR DESCRIPTION
…ocal)